### PR TITLE
docs: correct example i18n snippet in schema

### DIFF
--- a/bpmn-i18n.xsd
+++ b/bpmn-i18n.xsd
@@ -35,12 +35,12 @@
         <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" ... xml:lang="en">
         ...
         <bpmn:startEvent id="StartEvent_1" name="Start Event" isInterrupting="true">
+          <bpmn:documentation>A start event.</bpmn:documentation>
           <bpmn:extensionElements>
             <i18n:translation xml:lang="de">Startereignis</i18n:translation>
             <i18n:translation target="@isInterrupting" xml:lang="de">ja</i18n:translation>
             <i18n:translation target="documentation" xml:lang="de">Ein Startereignis.</i18n:translation>
           </bpmn:extensionElements>
-          <bpmn:documentation>A start event.</bpmn:documentation>
         </bpmn:startEvent>
         ...
         ]]>


### PR DESCRIPTION
The [example](https://github.com/bpmn-miwg/bpmn-i18n/blob/master/bpmn-i18n.xsd#L33) shows the following BPMN snippet:

```xml
        <bpmn:startEvent id="StartEvent_1" name="Start Event" isInterrupting="true">
          <bpmn:extensionElements>
            <i18n:translation xml:lang="de">Startereignis</i18n:translation>
            <i18n:translation target="@isInterrupting" xml:lang="de">ja</i18n:translation>
            <i18n:translation target="documentation" xml:lang="de">Ein Startereignis.</i18n:translation>
          </bpmn:extensionElements>
          <bpmn:documentation>A start event.</bpmn:documentation>
        </bpmn:startEvent>
```

Validating that fails, as `documentation` must be the first element in a node. This PR fixes the documentation